### PR TITLE
Add Next.js SaaS MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# WebsiteTest3
+# School SaaS MVP
+
+This project contains a minimal Next.js application that demonstrates a basic SaaS platform for local schools in West Bengal.
+
+## Getting Started
+
+Navigate to the project directory, install dependencies and run the development server:
+
+```bash
+cd nextjs-mvp
+npm install
+npm run dev
+```
+
+Then open [http://localhost:3000](http://localhost:3000) to see the app.
+
+The application includes a landing page, a simple login form that redirects to a dashboard, and basic styling.

--- a/nextjs-mvp/next-env.d.ts
+++ b/nextjs-mvp/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/nextjs-mvp/package.json
+++ b/nextjs-mvp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "school-saas-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.15.29",
+    "@types/react": "19.1.6",
+    "typescript": "5.8.3"
+  }
+}

--- a/nextjs-mvp/src/app/dashboard/page.tsx
+++ b/nextjs-mvp/src/app/dashboard/page.tsx
@@ -1,0 +1,8 @@
+export default function Dashboard() {
+  return (
+    <main className="p-6">
+      <h1 className="text-xl font-bold mb-4">Dashboard</h1>
+      <p>Welcome to your school dashboard. This is the starting point of your SaaS application.</p>
+    </main>
+  );
+}

--- a/nextjs-mvp/src/app/globals.css
+++ b/nextjs-mvp/src/app/globals.css
@@ -1,0 +1,10 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+main {
+  max-width: 640px;
+  margin: 0 auto;
+}

--- a/nextjs-mvp/src/app/layout.tsx
+++ b/nextjs-mvp/src/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/nextjs-mvp/src/app/login/page.tsx
+++ b/nextjs-mvp/src/app/login/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // For the MVP we just redirect to dashboard
+    router.push('/dashboard');
+  };
+
+  return (
+    <main className="p-6">
+      <h1 className="text-xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 max-w-sm">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          className="border p-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          className="border p-2"
+          required
+        />
+        <button type="submit" className="bg-blue-600 text-white p-2 rounded">
+          Sign In
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/nextjs-mvp/src/app/page.tsx
+++ b/nextjs-mvp/src/app/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">School SaaS MVP</h1>
+      <p className="mb-2">A simple platform for local schools in West Bengal.</p>
+      <ul className="list-disc pl-6">
+        <li>Online attendance tracking</li>
+        <li>Student report management</li>
+        <li>Parent-teacher communication</li>
+      </ul>
+      <div className="mt-4">
+        <Link href="/login" className="text-blue-600 underline">Login</Link>
+      </div>
+    </main>
+  );
+}

--- a/nextjs-mvp/tsconfig.json
+++ b/nextjs-mvp/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- create Next.js MVP inside `nextjs-mvp` folder
- add pages for landing, login and dashboard
- include minimal styles and layout
- update README with setup instructions
- ignore build artifacts and dependencies

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fc8b83b10832eaf49a4f69470db11